### PR TITLE
chore: Don't try to resolve now-sunset bintray repositories

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,2 @@
 // Common tox4j build rules.
-resolvers += Resolver.bintrayIvyRepo("toktok", "sbt-plugins")
 addSbtPlugin("org.toktok" % "sbt-plugins" % "0.1.6")


### PR DESCRIPTION
Building against a local repository still works fine, but the build
takes a lot longer as it has to time out trying to resolve bintray
repositories.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-macros/23)
<!-- Reviewable:end -->
