### PR TITLE
chore: Set up sbt CI using GitHub Actions

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,7 +1,7 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.23-third_party
+    image: toxchat/toktok-stack:0.0.31-release
     cpu: 2
     memory: 6G
   configure_script:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  sbt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up jvm-sbt-plugins
+        run: git clone https://github.com/TokTok/$REPO.git && cd $REPO && sbt publishLocal
+        env:
+          REPO: jvm-sbt-plugins
+      - name: Build and test
+        run: sbt -v +test


### PR DESCRIPTION
Since we currently don't publish the toktok/jvm-* artifacts anywhere, we build them from master and publish them into the local repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/jvm-macros/24)
<!-- Reviewable:end -->
